### PR TITLE
Lock theme to v4.13.0

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -12,7 +12,7 @@
 
 # theme                  : "minimal-mistakes-jekyll"
 # remote_theme           : "mmistakes/minimal-mistakes"
-remote_theme: "mmistakes/minimal-mistakes"
+remote_theme: "mmistakes/minimal-mistakes@4.13.0"
 minimal_mistakes_skin    : "default" # "air", "aqua", "contrast", "dark", "dirt", "neon", "mint", "plum", "sunrise"
 
 # Site Settings


### PR DESCRIPTION
Avoid issues like 

https://github.com/mom-ocean/mom-ocean.github.io/issues/8

occurring randomly by locking the theme to a version.