### PR TITLE
Updated home to include MOM6

### DIFF
--- a/_pages/home.md
+++ b/_pages/home.md
@@ -9,13 +9,36 @@ header:
   overlay_color: "#000"
   overlay_image: /assets/images/Southern_Ocean_waves.jpg
   caption: "Photo credit: Stephen M. Griffies"
-title: "MOM5"
+title: "MOM"
 excerpt: "Modular Ocean Model"
 
 ---
 
-MOM5 is a numerical ocean model based on the hydrostatic primitive equations, making use of the B-grid in the horizontal and generalized level coordinates for the vertical. 
+The Modular Ocean Model (MOM) describes the numerical ocean models originating
+from [NOAA/GFDL](http://www.gfdl.noaa.gov/ocean-model).  They are used to
+simulate ocean currents at both regional and global scales, enabling scientists
+to answer fundamental questions about the role of the ocean in the dynamics of
+the global climate.
 
-Development is led by scientists at [NOAA/GFDL](http://www.gfdl.noaa.gov/ocean-model) in collaboration with scientists worldwide. Much of the ongoing activity is centred in Australia. 
+MOM6 is the latest version of MOM.  It blends the techniques of traditional
+solvers with a dynamic vertical coordinate.  Development is led by an
+international consortium of scientists across several goverment agencies and
+academic institutions.
 
-Version 5 of MOM (MOM5) is an open source project released under the GPL license.  Contributions are welcome.  
+For more information about MOM6, visit the
+[development website](https://github.com/NOAA-GFDL/MOM6).
+
+MOM5 is the prior release of MOM, based on the hydrostatic primitive equations,
+a horizontal [B-grid](https://en.wikipedia.org/wiki/Arakawa_grids), and
+generalized level coordinates for the vertical.
+
+MOM5 continues to be an active component of many ocean and climate modeling
+systems around the world.  Development continues between NOAA/GFDL and its
+international partners, with much of the ongoing activity centered in
+Australia.
+
+More information about MOM5 is available at this website.  New users can begin
+with the [Quick-Start Guide](https://mom-ocean.github.io/docs/quick-start-guide/).
+
+Both models are open source projects released under GPL licenses.
+Contributions are welcome.


### PR DESCRIPTION
The home page was updated to reflect the parallel development of MOM5
and MOM6, with a link to the MOM6 development GitHub site.

Depending on how things go, we can add future MOM6 content if there is
an appetite for it.